### PR TITLE
Split plugin into two classes to avoid name conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To install ckanext-gitdatahub:
 
      `pip install ckanext-gitdatahub`
 
-3. Add `gitdatahub` to the `ckan.plugins` setting in your CKAN
+3. Add `gitdatahub_package gitdatahub_resource` to the `ckan.plugins` setting in your CKAN
    config file (by default the config file is located at
    `/etc/ckan/default/production.ini`).
 

--- a/ckanext/gitdatahub/plugin.py
+++ b/ckanext/gitdatahub/plugin.py
@@ -9,10 +9,9 @@ class GitDataHubException(Exception):
     pass
 
 
-class GitdatahubPlugin(plugins.SingletonPlugin):
+class PackageGitdatahubPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IPackageController, inherit=True)
-    plugins.implements(plugins.IResourceController, inherit=True)
 
     # IConfigurer
     def configure(self, config):
@@ -56,6 +55,18 @@ class GitdatahubPlugin(plugins.SingletonPlugin):
         client.create_or_update_lfspointerfile()
 
 
+    def delete(self, entity):
+        token = toolkit.config.get('ckanext.gitdatahub.access_token')
+        try:
+            client = CKANGitClient(token, dataset_name=entity.name)
+            client.delete_repo()
+        except Exception as e:
+            log.exception('Cannot delete {} repository.'.format(entity.name))
+
+
+class ResourceGitdatahubPlugin(plugins.SingletonPlugin):
+    plugins.implements(plugins.IResourceController, inherit=True)
+
     def before_delete(self, context, resource, resources):
         for obj in resources:
             if obj['id'] == resource['id']:
@@ -88,12 +99,3 @@ class GitdatahubPlugin(plugins.SingletonPlugin):
                 client.check_after_delete()
             except Exception as e:
                 log.exception('Cannot perfrom after_delete check .')
-
-
-    def delete(self, entity):
-        token = toolkit.config.get('ckanext.gitdatahub.access_token')
-        try:
-            client = CKANGitClient(token, dataset_name=entity.name)
-            client.delete_repo()
-        except Exception as e:
-            log.exception('Cannot delete {} repository.'.format(entity.name))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description=long_description,
 
     # The project's main homepage.
-    url='https://github.com/pdelboca/ckanext-gitdatahub',
+    url='https://github.com/datopian/ckanext-gitdatahub',
 
     # Author details
     author='''Patricio Del Boca''',
@@ -80,7 +80,8 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points='''
         [ckan.plugins]
-        gitdatahub=ckanext.gitdatahub.plugin:GitdatahubPlugin
+        gitdatahub_package=ckanext.gitdatahub.plugin:PackageGitdatahubPlugin
+        gitdatahub_resource=ckanext.gitdatahub.plugin:ResourceGitdatahubPlugin
 
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan


### PR DESCRIPTION
This PR splits the logics into two separated plugin classes to avoid names conflict between some methods in `IPackageController` and `IResourceController` like `after_update`.