### PR TITLE
Improves on CKANGitClient __init__

### DIFF
--- a/ckanext/gitdatahub/plugin.py
+++ b/ckanext/gitdatahub/plugin.py
@@ -56,9 +56,13 @@ class PackageGitdatahubPlugin(plugins.SingletonPlugin):
 
 
     def delete(self, entity):
+        pkg_dict = toolkit.get_action('package_show')(
+            {},
+            {'id': entity.id}
+        )
         token = toolkit.config.get('ckanext.gitdatahub.access_token')
         try:
-            client = CKANGitClient(token, dataset_name=entity.name)
+            client = CKANGitClient(token, pkg_dict)
             client.delete_repo()
         except Exception as e:
             log.exception('Cannot delete {} repository.'.format(entity.name))
@@ -79,7 +83,7 @@ class ResourceGitdatahubPlugin(plugins.SingletonPlugin):
         )
         token = toolkit.config.get('ckanext.gitdatahub.access_token')
         try:
-            client = CKANGitClient(token, dataset_name=pkg_dict['name'])
+            client = CKANGitClient(token, pkg_dict)
             client.delete_lfspointerfile(resource_dict['name'])
         except Exception as e:
             log.exception('Cannot delete {} lfspointerfile.'.format(resource_dict['name']))
@@ -95,7 +99,7 @@ class ResourceGitdatahubPlugin(plugins.SingletonPlugin):
             try:
                 #Checking whether the resoource is deleted from the database
                 #And there is no difference between the lfspointerfiles in repo and resouces in database
-                client = CKANGitClient(token, dataset_name=pkg_dict['name'])
+                client = CKANGitClient(token, pkg_dict)
                 client.check_after_delete(resources)
             except Exception as e:
-                log.exception('Cannot perfrom after_delete check .')
+                log.exception('Cannot perfrom after_delete check')

--- a/src/ckan_to_git.py
+++ b/src/ckan_to_git.py
@@ -6,18 +6,14 @@ from ckanapi.datapackage import dataset_to_datapackage
 log = logging.getLogger(__name__)
 
 class CKANGitClient:
-    def __init__(self, token, pkg_dict=None, dataset_name=None):
+    def __init__(self, token, pkg_dict):
         g = Github(token)
         self.auth_user = g.get_user()
         self.pkg_dict = pkg_dict
 
-        if not pkg_dict:
-            repo_name = dataset_name
-            repo_notes = None
-        else:
-            repo_name = pkg_dict['name']
-            # TODO: Review this key
-            repo_notes = pkg_dict['notes']
+        repo_name = pkg_dict['name']
+        # TODO: Review this key
+        repo_notes = pkg_dict['notes']
 
         self.repo = self.get_or_create_repo(repo_name, repo_notes)
 
@@ -31,9 +27,6 @@ class CKANGitClient:
         return repo
 
     def create_datapackage(self):
-        if not self.pkg_dict:
-            return
-
         body = dataset_to_datapackage(self.pkg_dict)
         self.repo.create_file(
             'datapackage.json',
@@ -42,9 +35,6 @@ class CKANGitClient:
             )
 
     def create_gitattributes(self):
-        if not self.pkg_dict:
-            return
-
         self.repo.create_file(
         '.gitattributes',
         'Create .gitattributes',
@@ -52,9 +42,6 @@ class CKANGitClient:
         )
 
     def create_lfsconfig(self, git_lfs_server_url):
-        if not self.pkg_dict:
-            return
-
         repoUrl = '{}/{}/{}'.format(git_lfs_server_url,self.auth_user.html_url.split('/')[-1],self.pkg_dict['name'])
         self.repo.create_file(
             '.lfsconfig',
@@ -63,9 +50,6 @@ class CKANGitClient:
             )
 
     def update_datapackage(self):
-        if not self.pkg_dict:
-            return
-
         contents = self.repo.get_contents("datapackage.json")
         body = dataset_to_datapackage(self.pkg_dict)
         self.repo.update_file(
@@ -76,9 +60,6 @@ class CKANGitClient:
             )
 
     def create_or_update_lfspointerfile(self):
-        if not self.pkg_dict:
-            return
-
         try:
             # TODO: Refactor this using LFSPointer objects
             lfs_pointers = [obj.name for obj in self.repo.get_contents("data")]


### PR DESCRIPTION
**Issue** #22

- Retrieve a `pkg_dict` before creating the client in the `delete` method
- Use that pkg_dict as a parameter for the initialization of `CKANGitClient` object.
- Cleaning the `_init__` by eliminating the dataset parameter which was just for the `delete` method
- No, need for the fixation of tests because CKANGitClient object for the `test_ckan_to_git` is already initializing bye pkg_dict and `test_delete_repo` is just calling the `delete_repo` method of CKANGitCient 
- Also, Updating the `before_delete` and `after_delete` in the `ResourceGitdatahubPlugin` by passing their pkg__dict for the initialization of the CKANGitClient object and same goes for their test.
