### PR TITLE
[IVT-2345] Write lfs pointer files only for objects stored in Git LFS

### DIFF
--- a/src/ckan_to_git.py
+++ b/src/ckan_to_git.py
@@ -69,11 +69,12 @@ class CKANGitClient:
             lfs_pointers = dict()
 
         for obj in self.pkg_dict['resources']:
-            if obj['name'] not in lfs_pointers.keys():
-                self.create_lfspointerfile(obj)
+            if obj['url_type'] == 'upload':
+                if obj['name'] not in lfs_pointers.keys():
+                    self.create_lfspointerfile(obj)
 
-            elif obj['sha256'] != lfs_pointers[obj['name']]:
-                self.update_lfspointerfile(obj)
+                elif obj['sha256'] != lfs_pointers[obj['name']]:
+                    self.update_lfspointerfile(obj)
 
     def get_sha256(self, lfspointerfile):
         file_path = "data/{}".format(lfspointerfile)


### PR DESCRIPTION
Issue : [IVT-2345](https://gatesfoundation.atlassian.net/browse/IVT-2345)
- Adding a check while creating or updating the LFS pointer files.