### PR TITLE
[IVT-2346] When the dataset has 2 or more resources with the same name, only one lfs pointer file is written

### DIFF
--- a/ckanext/gitdatahub/plugin.py
+++ b/ckanext/gitdatahub/plugin.py
@@ -84,7 +84,7 @@ class ResourceGitdatahubPlugin(plugins.SingletonPlugin):
         token = toolkit.config.get('ckanext.gitdatahub.access_token')
         try:
             client = CKANGitClient(token, pkg_dict)
-            lfspointer_name = resource_dict['id']+ '.' + resource_dict['format']
+            lfspointer_name = resource_dict['id'] + '.' + resource_dict['format']
             client.delete_lfspointerfile(lfspointer_name)
         except Exception as e:
             log.exception('Cannot delete {} lfspointerfile.'.format(resource_dict['name']))

--- a/ckanext/gitdatahub/plugin.py
+++ b/ckanext/gitdatahub/plugin.py
@@ -84,7 +84,8 @@ class ResourceGitdatahubPlugin(plugins.SingletonPlugin):
         token = toolkit.config.get('ckanext.gitdatahub.access_token')
         try:
             client = CKANGitClient(token, pkg_dict)
-            client.delete_lfspointerfile(resource_dict['name'])
+            lfspointer_name = resource_dict['id']+ '.' + resource_dict['format']
+            client.delete_lfspointerfile(lfspointer_name)
         except Exception as e:
             log.exception('Cannot delete {} lfspointerfile.'.format(resource_dict['name']))
 

--- a/src/ckan_to_git.py
+++ b/src/ckan_to_git.py
@@ -69,7 +69,7 @@ class CKANGitClient:
             lfs_pointers = dict()
 
         for obj in self.pkg_dict['resources']:
-            lfspointer_name = obj['id']+ '.' + obj['format']
+            lfspointer_name = obj['id'] + '.' + obj['format']
 
             if lfspointer_name not in lfs_pointers.keys():
                 self.create_lfspointerfile(obj)
@@ -86,7 +86,7 @@ class CKANGitClient:
         sha256 = obj['sha256']
         size = obj['size']
         lfs_pointer_body = 'version https://git-lfs.github.com/spec/v1\noid sha256:{}\nsize {}\n'.format(sha256, size)
-        lfspointer_name = obj['id']+ '.' + obj['format']
+        lfspointer_name = obj['id'] + '.' + obj['format']
 
         self.repo.create_file(
         "data/{}".format(lfspointer_name),
@@ -95,7 +95,7 @@ class CKANGitClient:
         )
 
     def update_lfspointerfile(self, obj):
-        lfspointer_name = obj['id']+ '.' + obj['format']
+        lfspointer_name = obj['id'] + '.' + obj['format']
         contents = self.repo.get_contents("data/{}".format(lfspointer_name))
         sha256 = obj['sha256']
         size = obj['size']

--- a/tests/test_ckan_to_git.py
+++ b/tests/test_ckan_to_git.py
@@ -48,19 +48,27 @@ class Test:
         assert repo_file_contents == lfsconfig_body
 
     def test_create_lfspointerfile(self):
-        obj = {'name': 'testing_resource.csv', 'size': 1024, 'sha256': '1234'}
+        obj = {'mimetype': 'text/csv', 'description': '',
+                'format': 'CSV', 'url': 'testing_resource.csv', 'name': 'testing_resource.csv', 'package_id': 'cee102b6-9e67-41b2-9558-46c9fe8fbe34',
+                'last_modified': datetime.datetime(2020, 4, 19, 12, 15, 48, 33024), 'url_type': 'upload',
+                'id': 'cc82cc39-3e66-4f77-bb34-fc90566fc612', 'size': 1024, 'sha256': '1234'}
         client.create_lfspointerfile(obj)
 
-        repo_file_contents = client.repo.get_contents("data/testing_resource.csv").decoded_content
+        lfspointer_name = obj['id']+ '.' + obj['format']
+        repo_file_contents = client.repo.get_contents("data/{}".format(lfspointer_name)).decoded_content
         lfs_pointer_body = bytes('version https://git-lfs.github.com/spec/v1\noid sha256:{}\nsize {}\n'.format(obj['sha256'], obj['size']), 'UTF-8')
 
         assert repo_file_contents == lfs_pointer_body
 
     def test_update_lfspointerfile(self):
-        obj = {'name': 'testing_resource.csv', 'size': 1024, 'sha256': '4321'}
+        obj = {'mimetype': 'text/csv', 'description': '',
+                'format': 'CSV', 'url': 'testing_resource.csv', 'name': 'testing_resource.csv', 'package_id': 'cee102b6-9e67-41b2-9558-46c9fe8fbe34',
+                'last_modified': datetime.datetime(2020, 4, 19, 12, 15, 48, 33024), 'url_type': 'upload',
+                'id': 'cc82cc39-3e66-4f77-bb34-fc90566fc612', 'size': 1024, 'sha256': '4321'}
         client.update_lfspointerfile(obj)
 
-        repo_file_contents = client.repo.get_contents("data/testing_resource.csv").decoded_content
+        lfspointer_name = obj['id']+ '.' + obj['format']
+        repo_file_contents = client.repo.get_contents("data/{}".format(lfspointer_name)).decoded_content
         lfs_pointer_body = bytes('version https://git-lfs.github.com/spec/v1\noid sha256:{}\nsize {}\n'.format(obj['sha256'], obj['size']), 'UTF-8')
 
         assert repo_file_contents == lfs_pointer_body
@@ -83,7 +91,13 @@ class Test:
         assert client.check_after_delete(resources) == False
 
     def test_delete_lfspointerfile(self):
-        assert client.delete_lfspointerfile('testing_resource.csv') == True
+        obj = {'mimetype': 'text/csv', 'description': '',
+                'format': 'CSV', 'url': 'testing_resource.csv', 'name': 'testing_resource.csv', 'package_id': 'cee102b6-9e67-41b2-9558-46c9fe8fbe34',
+                'last_modified': datetime.datetime(2020, 4, 19, 12, 15, 48, 33024), 'url_type': 'upload',
+                'id': 'cc82cc39-3e66-4f77-bb34-fc90566fc612', 'size': 1024, 'sha256': '1234'}
+        lfspointer_name = obj['id']+ '.' + obj['format']
+
+        assert client.delete_lfspointerfile(lfspointer_name) == True
 
     def test_check_after_successful_deletion(self):
         resources = [{'mimetype': 'text/csv', 'description': '',

--- a/tests/test_ckan_to_git.py
+++ b/tests/test_ckan_to_git.py
@@ -54,7 +54,7 @@ class Test:
                 'id': 'cc82cc39-3e66-4f77-bb34-fc90566fc612', 'size': 1024, 'sha256': '1234'}
         client.create_lfspointerfile(obj)
 
-        lfspointer_name = obj['id']+ '.' + obj['format']
+        lfspointer_name = obj['id'] + '.' + obj['format']
         repo_file_contents = client.repo.get_contents("data/{}".format(lfspointer_name)).decoded_content
         lfs_pointer_body = bytes('version https://git-lfs.github.com/spec/v1\noid sha256:{}\nsize {}\n'.format(obj['sha256'], obj['size']), 'UTF-8')
 
@@ -67,7 +67,7 @@ class Test:
                 'id': 'cc82cc39-3e66-4f77-bb34-fc90566fc612', 'size': 1024, 'sha256': '4321'}
         client.update_lfspointerfile(obj)
 
-        lfspointer_name = obj['id']+ '.' + obj['format']
+        lfspointer_name = obj['id'] + '.' + obj['format']
         repo_file_contents = client.repo.get_contents("data/{}".format(lfspointer_name)).decoded_content
         lfs_pointer_body = bytes('version https://git-lfs.github.com/spec/v1\noid sha256:{}\nsize {}\n'.format(obj['sha256'], obj['size']), 'UTF-8')
 
@@ -95,7 +95,7 @@ class Test:
                 'format': 'CSV', 'url': 'testing_resource.csv', 'name': 'testing_resource.csv', 'package_id': 'cee102b6-9e67-41b2-9558-46c9fe8fbe34',
                 'last_modified': datetime.datetime(2020, 4, 19, 12, 15, 48, 33024), 'url_type': 'upload',
                 'id': 'cc82cc39-3e66-4f77-bb34-fc90566fc612', 'size': 1024, 'sha256': '1234'}
-        lfspointer_name = obj['id']+ '.' + obj['format']
+        lfspointer_name = obj['id'] + '.' + obj['format']
 
         assert client.delete_lfspointerfile(lfspointer_name) == True
 


### PR DESCRIPTION
Issue: [IVT-2346](https://gatesfoundation.atlassian.net/browse/IVT-2346)

- Using `obj['id'] + '.' + obj['format']` for creating/updating the lfspointer for the resource instead of `obj['name']`.
- Using `obj['id'] + '.' + obj['format']` for deleting the resource as well.
- Updating the tests accordingly