### PR TITLE
[IVT-2326] Update gitdatahub to use a stand-alone library to convert from packages to datapacakge.json

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 PyGithub
-ckanapi
+ckan_datapackage_tools

--- a/src/ckan_to_git.py
+++ b/src/ckan_to_git.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from github import Github, UnknownObjectException
-from ckanapi.datapackage import dataset_to_datapackage
+import ckan_datapackage_tools.converter as converter
 
 log = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ class CKANGitClient:
         return repo
 
     def create_datapackage(self):
-        body = dataset_to_datapackage(self.pkg_dict)
+        body = converter.dataset_to_datapackage(self.pkg_dict)
         self.repo.create_file(
             'datapackage.json',
             'Create datapackage.json',
@@ -51,7 +51,7 @@ class CKANGitClient:
 
     def update_datapackage(self):
         contents = self.repo.get_contents("datapackage.json")
-        body = dataset_to_datapackage(self.pkg_dict)
+        body = converter.dataset_to_datapackage(self.pkg_dict)
         self.repo.update_file(
             contents.path,
             "Update datapackage.json",

--- a/tests/test_ckan_to_git.py
+++ b/tests/test_ckan_to_git.py
@@ -1,9 +1,8 @@
 import json
 import datetime
-from ckanapi.datapackage import dataset_to_datapackage
 from src.ckan_to_git import CKANGitClient
 import ckan.plugins.toolkit as toolkit
-
+import ckan_datapackage_tools.converter as converter
 from github import Github
 
 
@@ -23,7 +22,7 @@ class Test:
     def test_create_datapackage(self):
         client.create_datapackage()
 
-        body = dataset_to_datapackage(pkg_dict)
+        body = converter.dataset_to_datapackage(pkg_dict)
         repo_file_contents = client.repo.get_contents("datapackage.json").decoded_content
         datapackage_body = bytes(json.dumps(body, indent=2), 'UTF-8')
 
@@ -68,7 +67,7 @@ class Test:
     def test_update_datapackage(self):
         client.update_datapackage()
 
-        body = dataset_to_datapackage(pkg_dict)
+        body = converter.dataset_to_datapackage(pkg_dict)
         repo_file_contents = client.repo.get_contents("datapackage.json").decoded_content
         datapackage_body = bytes(json.dumps(body, indent=2), 'UTF-8')
 


### PR DESCRIPTION
Issue: [IVT-2326](https://gatesfoundation.atlassian.net/browse/IVT-2326)
- removes `ckanapi` from `requirements.txt` and adds `ckan_datapackage_tools`
- uses `dataset_to_datapackage()` method from `ckan_datapackage_tools.converter` in `ckan_to_git.py` and `tests_ckan_to_git.py`